### PR TITLE
Update entry

### DIFF
--- a/cat.js
+++ b/cat.js
@@ -233,6 +233,10 @@ function sendCustomHelpMessage(channelID) {
         {
           "name": "Example: Searching for an item in the catalogue",
           "value": "`!cat search item: diamond`"
+        },
+        {
+          "name": "Example: Updating an item in the catalogue",
+          "value": "`!cat update item: diamond price: 1 dirt`"
         }
       ]
     }

--- a/cat.js
+++ b/cat.js
@@ -53,13 +53,13 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 
     switch(action) {
       case 'add':
-        reply(user, channelID, `${addItemToCatalogue(user, args)}`);
+        reply(user, channelID, addItemToCatalogue(user, args));
         break;
       case 'update':
         reply(user, channelID, updateItemInCatalogue(user, args));
         break;
       case 'remove':
-        reply(user, channelID, `${removeItemFromCatalogue(user, args)}`);
+        reply(user, channelID, removeItemFromCatalogue(user, args));
         break;
       case 'search':
         const { resultCount, results } = botSearchResults(searchCatalogue(args));

--- a/cat.js
+++ b/cat.js
@@ -11,7 +11,7 @@ const bot = new Discord.Client({
 
 const botUsername = 'Catalogue';
 const catalogueFile = 'catalogue.json';
-const writeActions = ['add', 'remove'];
+const writeActions = ['add', 'remove', 'update'];
 let shoutedAt = false;
 let catalogue;
 
@@ -124,9 +124,10 @@ function updateItemInCatalogue(user, args) {
 }
 
 function updateCatalogueItem(listing, args) {
-  listing.quantity = args.quantity;
-  listing.price = args.price;
-  listing.location = args.location;
+  if (args.new_item) listing.item = args.new_item;
+  if (args.quantity) listing.quantity = args.quantity;
+  if (args.price) listing.price = args.price;
+  if (args.location) listing.location = args.location;
 
   updateLocalCatalogue();
 }
@@ -184,7 +185,7 @@ function searchCatalogue(args) {
 
 function parseInput(message) {
   const parsedArgs = {};
-  const knownArgs = ['item', 'quantity', 'price', 'location', 'seller'];
+  const knownArgs = ['item', 'quantity', 'price', 'location', 'seller', 'new_item'];
   knownArgs.forEach(arg => {
     let match = message.match(`${arg}:\\s?(.*?)(?=(?:\\s\\w*:|$))`);
     if (match) parsedArgs[arg] = toSafeString(match[1]);

--- a/cat.js
+++ b/cat.js
@@ -55,6 +55,9 @@ bot.on('message', function (user, userID, channelID, message, evt) {
       case 'add':
         reply(user, channelID, `${addItemToCatalogue(user, args)}`);
         break;
+      case 'update':
+        reply(user, channelID, updateItemInCatalogue(user, args));
+        break;
       case 'remove':
         reply(user, channelID, `${removeItemFromCatalogue(user, args)}`);
         break;
@@ -110,6 +113,24 @@ function createNewCatalogueEntry(user, args) {
   updateLocalCatalogue();
 }
 
+function updateItemInCatalogue(user, args) {
+  const listing = searchCatalogue({seller: user, item: args.item})[0];
+  if (listing) {
+    updateCatalogueItem(listing, args);
+    return `I've updated your **${args.item}** listing`;
+  }
+
+  return `I couldn't find a listing for **${args.item}** that belongs to you.`;
+}
+
+function updateCatalogueItem(listing, args) {
+  listing.quantity = args.quantity;
+  listing.price = args.price;
+  listing.location = args.location;
+
+  updateLocalCatalogue();
+}
+
 function removeItemFromCatalogue(user, args) {
   const listing = searchCatalogue({seller: user, item: args.item})[0];
   if (listing) {
@@ -137,27 +158,16 @@ function resultMessage(result) {
   // Seller and item will be present in a result,
   // but the other args are optional, so we need,
   // to create a 'modular' message.
-  const message = []
+  const message = [
+    `• **${toTitleCase(result.seller)}** is selling`,
+    `**${toTitleCase(result.item)}**`,
 
-  Object.keys(result).forEach(arg => {
-    switch(arg) {
-      case 'seller':
-        message.push(`• **${toTitleCase(result.seller)}** is selling`);
-        break;
-      case 'quantity':
-        message.push(`**${result.quantity}**`);
-        break;
-      case 'item':
-        message.push(`**${toTitleCase(result.item)}**`);
-        break;
-      case 'price':
-        message.push(`for **${toTitleCase(result.price)}**`);
-        break;
-      case 'location':
-        message.push(`at **${toTitleCase(result.location)}**`);
-        break;
-    }
-  });
+  ]
+  const presentArgs = Object.keys(result);
+
+  if (presentArgs.includes('quantity')) message.push(`**(${result.quantity})**`);
+  if (presentArgs.includes('price')) message.push(`for **${toTitleCase(result.price)}**`);
+  if (presentArgs.includes('location')) message.push(`at **${toTitleCase(result.location)}**`);
 
   return message.join(' ');
 }


### PR DESCRIPTION
Adds a basic `update` ability.  Allows updating any field of an existing listing. Example:

`!cat update item: diamond price: 1 dirt`

This syntax is slightly more confusing than the others because there's no obvious separation from the lookup arg (`item`) and the values it uses to update (anything after `item`)

One downside to this implementation is that there is no way to 'empty' an existing field, for example if my listing had a `price`, I wouldn't be able to remove that price.