### PR TITLE
Add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Some examples:
 
 Updating a listing takes 3 parts:
 
-1. The flag - used to specify which part of the isting to update (item name, price, location etc.)
+1. The flag - used to specify which part of the listing to update (item name, price, location etc.)
 2. The item - the existing name of the item to update
 3. The new value - this value will be applied to the field specified using the flag
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Discord Catalogue Bot
+
+Catalogue is a bot designed to make it easier to keep track of who is selling what. It allows sellers to add listings, and buyers to query them.
+
+### Adding a new listing
+
+The simplest way to add a listing, is:
+
+`!cat add item: [item]`
+
+This command also supports other arguments such as: `quantity:`, `price:`, `location:`. All of these are optional, and any of them can be added. An example of a more detailed catalogue addition:
+
+`!cat add item: book quantity: 5 price: 5 gold location: spawn`
+
+### Searching for listings
+
+The simplest way to search for a listing, is:
+
+`!cat search item: [item]`
+
+This command also supports other arguments such as: `seller:`, `location:`. These arguments, along with `item:` can be used freely to search the catalogue:
+
+`!cat search item: book`
+
+`!cat search item: book seller: John`
+
+`!cat search seller: John`
+
+`!cat search location: spawn`
+
+`!cat search item: book seller: John location: spawn`
+
+Searching is essentially filtering - it starts with the entire catalogue, then applies one filter after the other. `item: book seller: John` would first filter all listings down to `item: book` then filter that list by `seller: John`.
+
+All arguments for search are optional. If no valid arguments are provided then it'd just return all listings.
+
+### Updating a listing
+
+A listing is updated by referencing the item with the `item:` argument, then updating it with any arguments that follow, for example:
+
+`!cat update item: book price: 10 gold`
+
+This example would update the price of this user's book listing to 10 gold.
+
+This command also supports other arguments such as: `quantity:`, `price:`, `location:`. The item can be renamed with `new_item:`
+
+
+### Removing a listing
+
+The simplest way to remove a listing, is:
+
+`!cat remove item: [item]`
+
+This command accepts the same argument as adding a listing.

--- a/README.md
+++ b/README.md
@@ -6,49 +6,40 @@ Catalogue is a bot designed to make it easier to keep track of who is selling wh
 
 The simplest way to add a listing, is:
 
-`!cat add item: [item]`
+`!cat add [item]:[price]`
 
-This command also supports other arguments such as: `quantity:`, `price:`, `location:`. All of these are optional, and any of them can be added. An example of a more detailed catalogue addition:
+Specifying a location is also supported by following the above with `@[location]`, a full example might be:
 
-`!cat add item: book quantity: 5 price: 5 gold location: spawn`
+`!cat add book:5 gold @spawn`
 
 ### Searching for listings
 
 The simplest way to search for a listing, is:
 
-`!cat search item: [item]`
+`!cat search [item]`
 
-This command also supports other arguments such as: `seller:`, `location:`. These arguments, along with `item:` can be used freely to search the catalogue:
+It's possible to change the focus of the search using flags:
 
-`!cat search item: book`
+* `-i` - searches by item
+* `-u` - searches by user
+* `-l` - searches by location
 
-`!cat search item: book seller: John`
+Some examples:
 
-`!cat search seller: John`
+`!cat search book`
 
-`!cat search location: spawn`
+`!cat search -u bob`
 
-`!cat search item: book seller: John location: spawn`
-
-Searching is essentially filtering - it starts with the entire catalogue, then applies one filter after the other. `item: book seller: John` would first filter all listings down to `item: book` then filter that list by `seller: John`.
-
-All arguments for search are optional. If no valid arguments are provided then it'd just return all listings.
+`!cat search -l spawn`
 
 ### Updating a listing
 
-A listing is updated by referencing the item with the `item:` argument, then updating it with any arguments that follow, for example:
+Updating works similarly to searching in that the flag you pass determines which field is updated. For example if I wanted to update the item name from book to diamond, I would pass the `-i` flag, for example:
 
-`!cat update item: book price: 10 gold`
-
-This example would update the price of this user's book listing to 10 gold.
-
-This command also supports other arguments such as: `quantity:`, `price:`, `location:`. The item can be renamed with `new_item:`
-
+`!cat update -i book:diamond`
 
 ### Removing a listing
 
 The simplest way to remove a listing, is:
 
-`!cat remove item: [item]`
-
-This command accepts the same argument as adding a listing.
+`!cat remove [item]`

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ The simplest way to search for a listing, is:
 
 It's possible to change the focus of the search using flags:
 
-* `-i` - searches by item
+* `-i` - searches by item (default)
 * `-u` - searches by user
+* `-p` - searches by price
 * `-l` - searches by location
 
 Some examples:
@@ -34,9 +35,23 @@ Some examples:
 
 ### Updating a listing
 
-Updating works similarly to searching in that the flag you pass determines which field is updated. For example if I wanted to update the item name from book to diamond, I would pass the `-i` flag, for example:
+Updating a listing takes 3 parts:
 
-`!cat update -i book:diamond`
+1. The flag - used to specify which part of the isting to update (item name, price, location etc.)
+2. The item - the existing name of the item; used to find the listing to update
+3. The new value - this value will be applied to the field specified using the flag
+
+The flags in this case are similar to the ones used in searching:
+
+* `-i` - updates the name of the item
+* `-p` - updated the price of the item
+* `-l` - updates the location of the item
+
+Let's say you have an existing listing where you're selling 32 books for 10 gold at spawn, to update these fields:
+
+* Updating the item: `!cat update -i 32 books:64 books`
+* Updating the price: `!cat update -p 64 books:20 gold`
+* Updating the loction: `!cat search -l 64 books:plot 5`
 
 ### Removing a listing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The simplest way to add a listing, is:
 
 Specifying a location is also supported by following the above with `@[location]`, a full example might be:
 
-`!cat add book:5 gold @spawn`
+`!cat add 1 book:5 gold @spawn`
 
 ### Searching for listings
 
@@ -20,25 +20,23 @@ The simplest way to search for a listing, is:
 
 It's possible to change the focus of the search using flags:
 
-* `-i` - searches by item (default)
+* `-i` - searches by item (default if unspecified)
 * `-u` - searches by user
 * `-p` - searches by price
 * `-l` - searches by location
 
 Some examples:
 
-`!cat search book`
-
-`!cat search -u bob`
-
-`!cat search -l spawn`
+* Searching for all listings containing 'book': `!cat search book`
+* Searching for all listings by a user called Bob: `!cat search -u Bob`
+* Searching for all listings for items sold at spawn: `!cat search -l spawn`
 
 ### Updating a listing
 
 Updating a listing takes 3 parts:
 
 1. The flag - used to specify which part of the isting to update (item name, price, location etc.)
-2. The item - the existing name of the item; used to find the listing to update
+2. The item - the existing name of the item to update
 3. The new value - this value will be applied to the field specified using the flag
 
 The flags in this case are similar to the ones used in searching:
@@ -51,10 +49,14 @@ Let's say you have an existing listing where you're selling 32 books for 10 gold
 
 * Updating the item: `!cat update -i 32 books:64 books`
 * Updating the price: `!cat update -p 64 books:20 gold`
-* Updating the loction: `!cat search -l 64 books:plot 5`
+* Updating the loction: `!cat update -l 64 books:plot 5`
 
 ### Removing a listing
 
 The simplest way to remove a listing, is:
 
 `!cat remove [item]`
+
+For example to remove a book listing you created:
+
+`!cat remove book`

--- a/cat.js
+++ b/cat.js
@@ -50,8 +50,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
   
   if (message.includes('!cat ')) {
     const args = parseInput(message);
-    console.log(args)
-    if (!args.action || !argsValid(args)) return noComprendo(user, channelID);
+    if (!argsValid(args)) return noComprendo(user, channelID);
 
     user = user.toLowerCase();
 
@@ -73,7 +72,6 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 });
 
 function argsValid(args) {
-  console.log(args)
   switch(args.action) {
     case 'add':
       return !!args.primary && !!args.secondary;
@@ -82,7 +80,9 @@ function argsValid(args) {
     case 'update':
       return !!args.flag && !!args.primary && !!args.secondary;
     case 'search':
-      return !!args.primary
+      return !!args.primary;
+    default:
+      return false;
   }
 }
 
@@ -189,7 +189,8 @@ function resultMessage(result) {
 }
 
 function searchCatalogue(args) {
-  const query = queryFromFlag(args.flag);
+  const query = args.action === 'update' ? 'item' : queryFromFlag(args.flag);
+  console.log(`Searching listings by: ${query}`);
   try {
     return catalogue.listings.filter(e => e[query].includes(args.primary));
   } catch {
@@ -210,6 +211,10 @@ function queryFromFlag(flag) {
       return 'item'
     case 'l': // (l)ocation
       return 'location'
+    case 'p': // (p)rice
+      return 'price'
+    case 'c': // (c)ost (price alt
+      return 'price'
   }
 
   return 'item'; // default to item if no flag is specified
@@ -224,7 +229,7 @@ function parseInput(message) {
     optional: null,
   }
 
-  const re = `!cat (add|search|update|remove)\\s(\\-(u|i)\\s)?([^:@]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
+  const re = `!cat (add|search|update|remove)\\s(\\-(.)\\s)?([^:@]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
   const matchedArgs = message.match(re);
   
   if (!matchedArgs) return args;
@@ -252,6 +257,7 @@ function tidyArgs(args) {
     }
   });
 
+  console.log(args)
   return args;
 }
 

--- a/cat.js
+++ b/cat.js
@@ -28,51 +28,67 @@ if (!fs.existsSync(catalogueFile)) {
 }
 
 bot.on('message', function (user, userID, channelID, message, evt) {
+  if (user === botUsername) return;
+
   // The user might accidently have caps on, we don't want this to
   // not reach the bot, but we could have some fun with it..
-  if (message.includes('!CAT')) {
+  if (message.includes('!CAT ')) {
     shoutedAt = true;
     message = message.toLowerCase();
   }
   
-  if (message.includes('!cat') && user !== botUsername) {
-    const action = message.split(' ', 2)[1];
+  // Not all commands require args, let's handle them now.
+  if (message.includes('!cat help')) {
+    sendCustomHelpMessage(channelID);
+    return;
+  }
+
+  if (message.includes('c:reload')) {
+    loadCatalogue();
+    return;
+  }
+  
+  if (message.includes('!cat ')) {
     const args = parseInput(message);
+    console.log(args)
+    if (!args.action || !argsValid(args)) return noComprendo(user, channelID);
 
     user = user.toLowerCase();
 
-    if (action === 'help') {
-      sendCustomHelpMessage(channelID);
-      return;
-    }
-
-    if (writeActions.includes(action) && !args.item) {
-      reply(user, channelID, `Calling \`${action}\` requires an item. See \`!cat help\` for more information `);
-      return;
-    }
-
-    switch(action) {
+    switch(args.action) {
       case 'add':
         reply(user, channelID, addItemToCatalogue(user, args));
-        break;
-      case 'update':
-        reply(user, channelID, updateItemInCatalogue(user, args));
         break;
       case 'remove':
         reply(user, channelID, removeItemFromCatalogue(user, args));
         break;
+      case 'update':
+        reply(user, channelID, updateItemInCatalogue(user, args));
+        break;
       case 'search':
         const { resultCount, results } = botSearchResults(searchCatalogue(args));
         reply(user, channelID, `That query returned ${pluralize('result', resultCount, true)} \n\n${results}`);
-        break;
-      case 'c:reload':
-        loadCatalogue();
-        break;
-      default:
-        reply(user, channelID, "I don't understand that. See `!cat help` for more information");
     }
   }
 });
+
+function argsValid(args) {
+  console.log(args)
+  switch(args.action) {
+    case 'add':
+      return !!args.primary && !!args.secondary;
+    case 'remove':
+      return !!args.primary;
+    case 'update':
+      return !!args.flag && !!args.primary && !!args.secondary;
+    case 'search':
+      return !!args.primary
+  }
+}
+
+function noComprendo(user, channelID) {
+  reply(user, channelID, "I don't understand that. See `!cat help` for more information");
+}
 
 function reply(user, channelID, message) {
   let prefix = shoutedAt ? `HI, ${user.toUpperCase()}!!` : `Hi, ${toTitleCase(user)}!`;
@@ -95,20 +111,19 @@ function updateLocalCatalogue() {
 }
 
 function addItemToCatalogue(user, args) {
-  const existing = searchCatalogue({seller: user, item: args.item}).length > 0;
+  const existing = searchCatalogue(args).find(e => e.seller === user);
 
-  if (existing) return `You already have a **${toTitleCase(args.item)}** listing.`;
+  if (existing) return `You already have a **${toTitleCase(args.primary)}** listing.`;
   createNewCatalogueEntry(user, args);
-  return `I've added **${toTitleCase(args.item)}** to the catalogue for you`;
+  return `I've added **${toTitleCase(args.primary)}** to the catalogue for you`;
 }
 
 function createNewCatalogueEntry(user, args) {
   const newListing = {
     seller: user,
-    quantity: args.quantity,
-    item: args.item,
-    price: args.price,
-    location: args.location
+    item: args.primary,
+    price: args.secondary,
+    location: args.optional
   };
 
   Object.keys(newListing).forEach((key) => (newListing[key] == null) && delete newListing[key]);
@@ -118,32 +133,29 @@ function createNewCatalogueEntry(user, args) {
 }
 
 function updateItemInCatalogue(user, args) {
-  const listing = searchCatalogue({seller: user, item: args.item})[0];
+  const listing = searchCatalogue(args).find(e => e.seller === user);
   if (listing) {
     updateCatalogueItem(listing, args);
-    return `I've updated your **${args.item}** listing`;
+    return `I've updated your **${toTitleCase(args.primary)}** listing`;
   }
 
-  return `I couldn't find a listing for **${args.item}** that belongs to you.`;
+  return `I couldn't find a listing for **${toTitleCase(args.primary)}** that belongs to you.`;
 }
 
 function updateCatalogueItem(listing, args) {
-  if (args.new_item) listing.item = args.new_item;
-  if (args.quantity) listing.quantity = args.quantity;
-  if (args.price) listing.price = args.price;
-  if (args.location) listing.location = args.location;
-
+  const query = queryFromFlag(args.flag);
+  listing[query] = args.secondary;
   updateLocalCatalogue();
 }
 
 function removeItemFromCatalogue(user, args) {
-  const listing = searchCatalogue({seller: user, item: args.item})[0];
+  const listing = searchCatalogue(args).find(e => e.seller === user);
   if (listing) {
     deleteCatalogueEntry(listing);
-    return `I've removed your **${args.item}** listing`;
+    return `I've removed your **${args.primary}** listing`;
   }
 
-  return `I couldn't find a listing for **${args.item}** that belongs to you.`;
+  return `I couldn't find a listing for **${args.primary}** that belongs to you.`;
 }
 
 function deleteCatalogueEntry(listing) {
@@ -170,7 +182,6 @@ function resultMessage(result) {
 
   const presentArgs = Object.keys(result);
 
-  if (presentArgs.includes('quantity')) message.push(`**(${result.quantity})**`);
   if (presentArgs.includes('price')) message.push(`for **${toTitleCase(result.price)}**`);
   if (presentArgs.includes('location')) message.push(`at **${toTitleCase(result.location)}**`);
 
@@ -178,24 +189,70 @@ function resultMessage(result) {
 }
 
 function searchCatalogue(args) {
-  // When a search is done, we don't know which args will be passed in which order.
-  // This is a weird solution but it allows for any combination of these args.
-  let currentListings = catalogue.listings;
-  if (args.seller) currentListings = currentListings.filter(e => e.seller === args.seller);
-  if (args.item) currentListings = currentListings.filter(e => e.item.startsWith(args.item));
-  if (args.location) currentListings = currentListings.filter(e => e.location === args.location);
-  return currentListings;
+  const query = queryFromFlag(args.flag);
+  try {
+    return catalogue.listings.filter(e => e[query].includes(args.primary));
+  } catch {
+    console.log(`Search for ${query} failed; likely not a valid field.`);
+    return [];
+  }
+}
+
+function queryFromFlag(flag) {
+  switch(flag) {
+    case 's': // (s)eller
+      return 'seller';
+    case 'u': // (u)ser (seller alt)
+      return 'seller';
+    case 'i': // (i)tem
+      return 'item'
+    case 'b': // (b)lock (item alt)
+      return 'item'
+    case 'l': // (l)ocation
+      return 'location'
+  }
+
+  return 'item'; // default to item if no flag is specified
 }
 
 function parseInput(message) {
-  const parsedArgs = {};
-  const knownArgs = ['item', 'quantity', 'price', 'location', 'seller', 'new_item'];
-  knownArgs.forEach(arg => {
-    let match = message.match(`${arg}:\\s?(.*?)(?=(?:\\s\\w*:|$))`);
-    if (match) parsedArgs[arg] = toSafeString(match[1]);
+  const args = {
+    action: null,
+    flag: null,
+    primary: null,
+    secondary: null,
+    optional: null,
+  }
+
+  const re = `!cat (add|search|update|remove)\\s(\\-(u|i)\\s)?([^:@]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
+  const matchedArgs = message.match(re);
+  
+  if (!matchedArgs) return args;
+
+  args.action = matchedArgs[1];
+  args.flag = matchedArgs[3]
+  args.primary = matchedArgs[4];
+  args.secondary = matchedArgs[5];
+  args.optional = matchedArgs[6];
+
+  return tidyArgs(args);
+}
+
+function tidyArgs(args) {
+  // We're settings all args in one place
+  // but not all args will always be present.
+  // This will remove any args that weren't
+  // specified, and fix the values of the
+  // ones that were.
+  Object.keys(args).forEach((key) => {
+    if (args[key] == null) {
+      delete args[key];
+    } else {
+      args[key] = toSafeString(args[key]);
+    }
   });
 
-  return parsedArgs;
+  return args;
 }
 
 function toTitleCase(str) {
@@ -221,7 +278,7 @@ function sendCustomHelpMessage(channelID) {
     to: channelID,
     message: "Here's some basic information about me",
     embed: {
-      "description":"Catalogue is a bot designed to make it easier to keep track of who is selling what. It allows sellers to add listings, and buyers to query them. Click [here](https://github.com/TyRoberts/discord-item-catalogue) for more information.",
+      "description":"Catalogue is a bot designed to make it easier to keep track of who is selling what. It allows sellers to add listings, and buyers to query them. Click [here](https://github.com/TyRoberts/discord-item-catalogue) for more information on usage.",
       "color":3447003,
       "thumbnail": {
         "url": "https://gamepedia.cursecdn.com/minecraft_gamepedia/8/85/Knowledge_book.png?version=0c9d97dd48215c6faa9e4513f5d87aa8"
@@ -229,19 +286,15 @@ function sendCustomHelpMessage(channelID) {
       "fields": [
         {
           "name": "Example: Adding an item to the catalogue",
-          "value": "`!cat add item: diamond`"
+          "value": "`!cat add 64 diamonds:64 iron @spawn`"
         },
         {
           "name": "Example: Removing an item in the catalogue",
-          "value": "`!cat remove item: diamond`"
+          "value": "`!cat remove diamond`"
         },
         {
-          "name": "Example: Searching for an item in the catalogue",
-          "value": "`!cat search item: diamond`"
-        },
-        {
-          "name": "Example: Updating an item in the catalogue",
-          "value": "`!cat update item: diamond price: 1 dirt`"
+          "name": "Example: Searching the catalogue for an item",
+          "value": "`!cat search diamond`"
         }
       ]
     }

--- a/cat.js
+++ b/cat.js
@@ -133,6 +133,7 @@ function createNewCatalogueEntry(user, args) {
 }
 
 function updateItemInCatalogue(user, args) {
+  if (['u', 's'].includes(args.flag)) return 'You cannot update the name of the seller!';
   const listing = searchCatalogue(args).find(e => e.seller === user);
   if (listing) {
     updateCatalogueItem(listing, args);

--- a/cat.js
+++ b/cat.js
@@ -65,6 +65,9 @@ bot.on('message', function (user, userID, channelID, message, evt) {
         const { resultCount, results } = botSearchResults(searchCatalogue(args));
         reply(user, channelID, `That query returned ${pluralize('result', resultCount, true)} \n\n${results}`);
         break;
+      case 'c:reload':
+        loadCatalogue();
+        break;
       default:
         reply(user, channelID, "I don't understand that. See `!cat help` for more information");
     }
@@ -72,7 +75,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 });
 
 function reply(user, channelID, message) {
-  let prefix = shoutedAt ? `HI, ${user.toUpperCase()}!!` : `Hi, ${toTitleCase(user)}!`
+  let prefix = shoutedAt ? `HI, ${user.toUpperCase()}!!` : `Hi, ${toTitleCase(user)}!`;
   bot.sendMessage({
     to: channelID,
     message: `${prefix} ${message}`
@@ -88,7 +91,6 @@ function updateLocalCatalogue() {
       return;
     };
     console.log("Catalogue updated.");
-    loadCatalogue();
   });
 }
 
@@ -107,7 +109,9 @@ function createNewCatalogueEntry(user, args) {
     item: args.item,
     price: args.price,
     location: args.location
-  }
+  };
+
+  Object.keys(newListing).forEach((key) => (newListing[key] == null) && delete newListing[key]);
 
   catalogue.listings.push(newListing);
   updateLocalCatalogue();
@@ -144,7 +148,7 @@ function removeItemFromCatalogue(user, args) {
 
 function deleteCatalogueEntry(listing) {
   const index = catalogue.listings.indexOf(listing);
-  catalogue.listings.splice(index, 1)
+  catalogue.listings.splice(index, 1);
   updateLocalCatalogue();
 }
 
@@ -152,7 +156,7 @@ function botSearchResults(results) {
   return {
     resultCount: results.length,
     results: results.map(result => resultMessage(result)).join("\n"),
-  }
+  };
 }
 
 function resultMessage(result) {
@@ -162,8 +166,8 @@ function resultMessage(result) {
   const message = [
     `• **${toTitleCase(result.seller)}** is selling`,
     `**${toTitleCase(result.item)}**`,
+  ];
 
-  ]
   const presentArgs = Object.keys(result);
 
   if (presentArgs.includes('quantity')) message.push(`**(${result.quantity})**`);
@@ -189,7 +193,7 @@ function parseInput(message) {
   knownArgs.forEach(arg => {
     let match = message.match(`${arg}:\\s?(.*?)(?=(?:\\s\\w*:|$))`);
     if (match) parsedArgs[arg] = toSafeString(match[1]);
-  })
+  });
 
   return parsedArgs;
 }
@@ -209,6 +213,7 @@ function toSafeString(str) {
 
 function loadCatalogue() {
   catalogue = JSON.parse(fs.readFileSync(catalogueFile));
+  console.log('Catalogue loaded from file.');
 }
 
 function sendCustomHelpMessage(channelID) {
@@ -216,7 +221,7 @@ function sendCustomHelpMessage(channelID) {
     to: channelID,
     message: "Here's some basic information about me",
     embed: {
-      "description":"Catalogue is a bot designed to make it easier to keep track of what is being sold, by allowing users to _add_ items to it, and query existing items within it. Click [here](https://github.com/TyRoberts/discord-item-catalogue) for more information.",
+      "description":"Catalogue is a bot designed to make it easier to keep track of who is selling what. It allows sellers to add listings, and buyers to query them. Click [here](https://github.com/TyRoberts/discord-item-catalogue) for more information.",
       "color":3447003,
       "thumbnail": {
         "url": "https://gamepedia.cursecdn.com/minecraft_gamepedia/8/85/Knowledge_book.png?version=0c9d97dd48215c6faa9e4513f5d87aa8"


### PR DESCRIPTION
As the branch name suggests this was intended to be a README but I ended up completely redoing how the bot is interacted with 🤷‍♂ 

**Was:**

`!cat add item: Books quantity: 32 price: 5 gold location: spawn`

`!cat search item: book`

`!cat update item: book price: 10 gold`

`!cat remove item: book`

**Now**

`!cat add 32 books:10 gold @spawn`

`!cat search book`

`!cat update -p book:10 gold`

`!cat remove book`

---

This also:

* Makes the command prefix just `!cat` - previously it would accept anything that _started_ with `!cat` but all examples use this, it's the easiest to type, and it's unaffected by locales
* Renamed internal arg values to be less specific - `item`, `price` becomes `primary`, `secondary`. This is because the old values aren't always accurate, especially with the new flag system where the "second" value won't always be price.
* Better enforced arg presence - the action (`add`, `remove` ..) and the primary arg (typically the item) are always required, but the flag, and the secondary values are not. We need to ensure that no paths are blocked by requiring args that aren't actually required, nor allowing access without args that are.