### PR TITLE
Improve search

### DIFF
--- a/cat.js
+++ b/cat.js
@@ -40,7 +40,7 @@ function promptHelp(message) {
 
 function invalidArgsReason(message, usage) {
   const user = message.author.username;
-  message.channel.send(`Hi, ${user}! Here's how you use that \`${usage}\``);
+  message.channel.send(`Hi, ${user}! Here's how you use that \`${usage}\`. See \`!cat help\` for more usage information.`);
 }
 
 let catalogue;

--- a/cat_modules/parse_input.js
+++ b/cat_modules/parse_input.js
@@ -1,7 +1,7 @@
 exports.run = (message, commands) => {
   const logger = require('winston');
   function toSafeString(str) {
-    return str.replace(/[^ \w-@']+/g, '').trim();
+    return str.replace(/[^ \w-@*']+/g, '').trim();
   }
 
   function tidyArgs(args) {

--- a/cat_modules/parse_input.js
+++ b/cat_modules/parse_input.js
@@ -1,7 +1,7 @@
 exports.run = (message, commands) => {
   const logger = require('winston');
   function toSafeString(str) {
-    return str.replace(/[^ \w-']+/g, '').trim();
+    return str.replace(/[^ \w-@']+/g, '').trim();
   }
 
   function tidyArgs(args) {
@@ -19,7 +19,7 @@ exports.run = (message, commands) => {
   const args = {};
   const actions = commands.map(c => c.name);
 
-  const re = `!cat (${actions.join('|')})\\s?(\\-(.)\\s)?([^:@]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
+  const re = `!cat (${actions.join('|')})\\s?(\\-(.)\\s)?([^:]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
   const matchedArgs = message.match(re);
   
   if (!matchedArgs) return args;

--- a/cat_modules/query_from_flag.js
+++ b/cat_modules/query_from_flag.js
@@ -1,0 +1,18 @@
+exports.run = (flag) => {
+  switch(flag) {
+    case 's': // (s)eller
+      return 'seller';
+    case 'u': // (u)ser (seller alt)
+      return 'seller';
+    case 'i': // (i)tem
+      return 'item';
+    case 'b': // (b)lock (item alt)
+      return 'item';
+    case 'l': // (l)ocation
+      return 'location';
+    case 'p': // (p)rice
+      return 'price';
+  }
+
+  return 'item'; // default to item if no flag is specified
+}

--- a/cat_modules/search_catalogue.js
+++ b/cat_modules/search_catalogue.js
@@ -2,6 +2,7 @@ exports.run = (catalogue, args) => {
   const logger = require('winston');
   const queryFromFlag = require('../cat_modules/query_from_flag');
 
+  const flag = args.flag;
   let query;
 
   if (args.action == 'update') {
@@ -11,7 +12,10 @@ exports.run = (catalogue, args) => {
     args.flag = 'l';
   }
 
+  args.primary = args.primary.replace('*', '');
+
   query = queryFromFlag.run(args.flag);
+  args.flag = flag;
 
   logger.info(`Searching catalogue for: "${args.primary}" by: "${query}"`);
 

--- a/cat_modules/search_catalogue.js
+++ b/cat_modules/search_catalogue.js
@@ -1,26 +1,19 @@
 exports.run = (catalogue, args) => {
   const logger = require('winston');
+  const queryFromFlag = require('../cat_modules/query_from_flag');
 
-  function queryFromFlag(flag) {
-    switch(flag) {
-      case 's': // (s)eller
-        return 'seller';
-      case 'u': // (u)ser (seller alt)
-        return 'seller';
-      case 'i': // (i)tem
-        return 'item';
-      case 'b': // (b)lock (item alt)
-        return 'item';
-      case 'l': // (l)ocation
-        return 'location';
-      case 'p': // (p)rice
-        return 'price';
-    }
+  let query;
 
-    return 'item'; // default to item if no flag is specified
+  if (args.action == 'update') {
+    args.flag = 'i';
+  } else if (args.primary.startsWith('@')) {
+    args.primary = args.primary.substring(1);
+    args.flag = 'l';
   }
 
-  const query = args.action === 'update' ? 'item' : queryFromFlag(args.flag);
+  query = queryFromFlag.run(args.flag);
+
+  logger.info(`Searching catalogue for: "${args.primary}" by: "${query}"`);
 
   try {
     const listings = catalogue.listings.filter(listing => listing[query]);

--- a/cat_modules/search_catalogue.js
+++ b/cat_modules/search_catalogue.js
@@ -2,20 +2,19 @@ exports.run = (catalogue, args) => {
   const logger = require('winston');
   const queryFromFlag = require('../cat_modules/query_from_flag');
 
-  const flag = args.flag;
+  let flag = args.flag;
   let query;
 
   if (args.action == 'update') {
-    args.flag = 'i';
+    flag = 'i';
   } else if (args.primary.startsWith('@')) {
     args.primary = args.primary.substring(1);
-    args.flag = 'l';
+    flag = 'l';
   }
 
   args.primary = args.primary.replace('*', '');
 
-  query = queryFromFlag.run(args.flag);
-  args.flag = flag;
+  query = queryFromFlag.run(flag);
 
   logger.info(`Searching catalogue for: "${args.primary}" by: "${query}"`);
 

--- a/commands/search.js
+++ b/commands/search.js
@@ -4,6 +4,7 @@ module.exports = {
   execute(message, catalogue, args) {
     const pluralize = require('pluralize');
     const catalogueSearch = require('./../cat_modules/search_catalogue');
+    const queryFromFlag = require('../cat_modules/query_from_flag');
 
     function resultMessage(result) {
       let message = `• **${result.seller}** is selling **${result.item}** for **${result.price}**`;
@@ -22,7 +23,7 @@ module.exports = {
     const multiMessage = [];
     const user = message.author.username;
     const results = catalogueSearch.run(catalogue, args);
-    let messageCap = `Hi, ${user}! That query returned ${pluralize('result', results.length, true)} \n\n`;
+    let messageCap = `Hi, ${user}! ${queryFromFlag.run(args.flag)} search for **${args.primary}** returned ${pluralize('result', results.length, true)} \n\n`;
 
     results.forEach(result => {
       listing = resultMessage(result);

--- a/commands/search.js
+++ b/commands/search.js
@@ -1,5 +1,6 @@
 module.exports = {
   name: 'search',
+  usage: '!cat search [option] [item]',
   description: 'test',
   execute(message, catalogue, args) {
     const pluralize = require('pluralize');
@@ -23,7 +24,7 @@ module.exports = {
     const multiMessage = [];
     const user = message.author.username;
     const results = catalogueSearch.run(catalogue, args);
-    let messageCap = `Hi, ${user}! ${queryFromFlag.run(args.flag)} search for **${args.primary}** returned ${pluralize('result', results.length, true)} \n\n`;
+    let messageCap = `Hi, ${user}! That ${queryFromFlag.run(args.flag)} search returned ${pluralize('result', results.length, true)} \n\n`;
 
     results.forEach(result => {
       listing = resultMessage(result);
@@ -43,6 +44,6 @@ module.exports = {
   },
 
   valid(args) {
-    return true;
+    return !!args.primary;
   }
 }

--- a/commands/update.js
+++ b/commands/update.js
@@ -4,22 +4,10 @@ module.exports = {
   execute(message, catalogue, args) {
     const catalogueSearch = require('./../cat_modules/search_catalogue');
     const catalogueUpdate = require('./../cat_modules/update_catalogue');
-
-    function queryFromFlag(flag) {
-      switch(flag) {
-        case 'i':
-          return 'item';
-        case 'l':
-          return 'location';
-        case 'p':
-          return 'price';
-      }
-    
-      return 'item';
-    }
+    const queryFromFlag = require('../cat_modules/query_from_flag');
 
     function updateCatalogueItem(listing, args) {
-      const query = queryFromFlag(args.flag);
+      const query = queryFromFlag.run(args.flag);
       listing[query] = args.secondary;
       catalogueUpdate.run(catalogue);
     }


### PR DESCRIPTION
I'm starting to think including '@' in the command wasn't a great idea. It makes adding items look quite cool, but '@' is already reserved for tagging a user.. so this may cause confusion.

Despite this, I've seen people searching for location with it, so instead of changing the way location is specified I've allowed searching by location with '@':

`!cat search @plot 1`

I've also tweaked the bot response message to include what it searched _by_:

```
Hi, Ty! That item search returned 1 result
Hi, Ty! That price search returned 1 result 
Hi, Ty! That location search returned 1 result 
Hi, Ty! That seller search returned 1 result 
```

I've also re-added the usage constraint for searching to require the primary argument, but explicitly allowed '*' to be a primary argument for when a wider search is needed.

`!cat search *` 