### PR TITLE
Fix being unable to update a listing with caps in it

### DIFF
--- a/commands/update.js
+++ b/commands/update.js
@@ -10,7 +10,7 @@ module.exports = {
     const user = message.author.username;
 
     let sql = `SELECT rowid, * FROM listings
-               WHERE item = LOWER("${args.primary}")
+               WHERE item = "${args.primary}"
                AND seller = "${user}"`
 
     const listingsSearch = catalogueSearch.run(sql);


### PR DESCRIPTION
This query was incorrectly converting the input to lowercase. This resulted in being unable to update any listings with capital letters in the name (e.g. `1 Book`)
