### PR TITLE
Fix being unable to remove a listing with caps in it

### DIFF
--- a/commands/remove.js
+++ b/commands/remove.js
@@ -9,7 +9,7 @@ module.exports = {
     const user = message.author.username;
 
     const sql = `SELECT rowid, * FROM listings
-                 WHERE item = LOWER("${args.primary}")
+                 WHERE item = "${args.primary}"
                  AND seller = "${user}"
                  LIMIT 1`
 


### PR DESCRIPTION
This query was incorrectly converting the input to lowercase. This resulted in being unable to remove any listings with capital letters in the name (e.g. 1 Book)