### PR TITLE
Allow a different type of apostrophe

### DIFF
--- a/cat_modules/parse_input.js
+++ b/cat_modules/parse_input.js
@@ -1,7 +1,7 @@
 exports.run = (message, commands) => {
   const logger = require('winston');
   function toSafeString(str) {
-    return str.replace(/[^ \w-@*()\[\]_#,\.']+/g, '').trim();
+    return str.replace(/[^ \w-@*()\[\]_#,\.'’]+/g, '').trim();
   }
 
   function tidyArgs(args) {


### PR DESCRIPTION
I'm being a bit lazy when it comes to filtering input and should probably revisit it at some point to do it properly.

I see people using `’` instead of `'` and it's being filtered out. For now just add it to the list of 'safe' characters.