### PR TITLE
Tweak search output if location is present

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -9,8 +9,7 @@ module.exports = {
     const pluralize = require('pluralize');
 
     function resultMessage(result) {
-      let message = `• **${result.location || result.seller}** is selling **${result.item}** for **${result.price}**`;
-      return message + "\n";
+      return `• **${result.location || result.seller}** is selling **${result.item}** for **${result.price}**` + "\n";
     }
 
     function botSearchResults(results) {

--- a/commands/search.js
+++ b/commands/search.js
@@ -9,8 +9,7 @@ module.exports = {
     const pluralize = require('pluralize');
 
     function resultMessage(result) {
-      let message = `• **${result.seller}** is selling **${result.item}** for **${result.price}**`;
-      if (result.location) message = message + ` at **${result.location}**`;
+      let message = `• **${result.location || result.seller}** is selling **${result.item}** for **${result.price}**`;
       return message + "\n";
     }
 


### PR DESCRIPTION
A location can be added to a listing for added detail, for example:

`[USER] is selling [ITEM] for [PRICE] at [LOCATION]`

I think this could be shortened. If location is specified then why not use it in place of the user? And if the location isn't specified then it'd be as it was anyway.

**Without**: `[USER] is selling [ITEM] for [PRICE]`
**With**: `[LOCATION] is selling [ITEM] for [PRICE]`

This may not work for locations that aren't a shop, but I've yet to see any listing location that isn't.