### PR TITLE
Basic admin listing removal

### DIFF
--- a/cat.js
+++ b/cat.js
@@ -1,4 +1,4 @@
-const { prefix, token } = require('./config.json');
+const { prefix, token, admin_ids } = require('./config.json');
 const inputParse  = require('./cat_modules/parse_input');
 const db          = require('./cat_modules/db');
 const Discord     = require('discord.js');
@@ -28,6 +28,12 @@ client.on('message', message => {
   const action = client.commands.get(args.action);
 
   if (!action.valid(args)) return invalidArgsReason(message, action.usage);
+
+  // if (!admin_ids.includes(message.author.id)) {
+  //   message.channel.send(`**In dev** Sorry, ${message.author.username}. I'm a local bot for development purposes so the catalogue is currently unavailalble.`);
+
+  //   return;
+  // }
 
   try {
     action.execute(message, args);

--- a/cat_modules/search_catalogue.js
+++ b/cat_modules/search_catalogue.js
@@ -1,6 +1,6 @@
 exports.run = (sql) => {
   const logger = require('winston');
-  const sqlite = require('./../cat_modules/db');
+  const sqlite = require('./db');
   const db = sqlite.load();
 
   logger.info(sql)

--- a/commands/add.js
+++ b/commands/add.js
@@ -2,7 +2,7 @@ module.exports = {
   name: 'add',
   usage: '!cat add [item]:[price]',
   execute(message, args) {
-    const sqlite = require('./../cat_modules/db');
+    const sqlite = require('../cat_modules/db');
     const db = sqlite.load();
     const user = message.author.username;
 

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -3,14 +3,16 @@ module.exports = {
   usage: '!cat remove [item]',
   execute(message, args) {
     const logger = require('winston');
-    const catalogueSearch = require('./../cat_modules/search_catalogue');
-    const sqlite = require('./../cat_modules/db');
+    const catalogueSearch = require('../cat_modules/search_catalogue');
+    const sqlite = require('../cat_modules/db');
+    const { admin_ids } = require('../config.json');
     const db = sqlite.load();
     const user = message.author.username;
+    const admin = admin_ids.includes(message.author.id);
 
-    const sql = `SELECT rowid, * FROM listings
-                 WHERE item = "${args.primary}"
-                 AND seller = "${user}"
+    const sql = `SELECT rowid, '*' FROM listings
+                 WHERE item = "${args.primary}" OR rowid = "${args.primary}"
+                 AND seller ${admin ? "LIKE '%'" : `= "${user}"`}
                  LIMIT 1`
 
     const listingsSearch = catalogueSearch.run(sql);

--- a/commands/search.js
+++ b/commands/search.js
@@ -5,11 +5,12 @@ module.exports = {
   execute(message, args) {
     const logger = require('winston');
     const queryFromFlag = require('../cat_modules/query_from_flag');
-    const catalogueSearch = require('./../cat_modules/search_catalogue');
+    const catalogueSearch = require('../cat_modules/search_catalogue');
     const pluralize = require('pluralize');
 
     function resultMessage(result) {
-      return `• **${result.location || result.seller}** is selling **${result.item}** for **${result.price}**` + "\n";
+      const id = args.flag === 'v' ? `[${result.rowid}] ` : ''
+      return `• ${id}**${result.location || result.seller}** is selling **${result.item}** for **${result.price}**` + "\n";
     }
 
     function botSearchResults(results) {
@@ -24,7 +25,7 @@ module.exports = {
       args.primary = args.primary.substring(1);
     }
 
-    const sql = `SELECT * FROM listings
+    const sql = `SELECT rowid, * FROM listings
                  WHERE LOWER(${queryFromFlag.run(args.flag)})
                  LIKE LOWER("%${args.primary.replace('*', '')}%")`
 

--- a/commands/update.js
+++ b/commands/update.js
@@ -3,9 +3,9 @@ module.exports = {
   usage: '!cat update [option] [item]:[term]',
   execute(message, args) {
     const logger = require('winston');
-    const catalogueSearch = require('./../cat_modules/search_catalogue');
+    const catalogueSearch = require('../cat_modules/search_catalogue');
     const queryFromFlag = require('../cat_modules/query_from_flag');
-    const sqlite = require('./../cat_modules/db');
+    const sqlite = require('../cat_modules/db');
     const db = sqlite.load();
     const user = message.author.username;
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,8 @@
 {
 	"prefix": "",
 	"helpIcon": "",
-	"token": ""
+	"token": "",
+	"admin ids": [
+		
+	]
 }


### PR DESCRIPTION
This allows certain users to remove anyone's listing.

If a Discord user ID is defined in the `admin_ids` list in the config, they will be able to remove any other user's listing. This is useful for admins to clear up stale listings from users who are no longer active.