### PR TITLE
Remove embedded help information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.json
 node_modules/
 db/catalogue.db
 cata.log
+help.json

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,32 +1,9 @@
 module.exports = {
   name: 'help',
   execute(message, catalogue, args) {
-    const { helpIcon } = require('../config.json');
+    const description = require('../help.json');
 
-    message.channel.send({
-      "content": "Here's some basic information about me",
-      "embed": {
-        "description":"Catalogue is a bot designed to make it easier to keep track of who is selling what. It allows sellers to add listings, and buyers to query them. Click [here](https://github.com/TyRoberts/discord-item-catalogue#discord-catalogue-bot) for more information on usage.",
-        "color":3447003,
-        "thumbnail": {
-          "url": helpIcon
-        },
-        "fields": [
-          {
-            "name": "Example: Adding an item to the catalogue",
-            "value": "`!cat add 1 beacon:32 diamonds @spawn`"
-          },
-          {
-            "name": "Example: Removing an item in the catalogue",
-            "value": "`!cat remove 1 beacon`"
-          },
-          {
-            "name": "Example: Searching the catalogue for an item",
-            "value": "`!cat search beacon`"
-          }
-        ]
-      }
-    });
+    message.channel.send(description);
   },
 
   valid(args) {

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,5 @@
 {
 	"prefix": "",
-	"helpIcon": "",
 	"token": "",
 	"admin ids": [
 		

--- a/help.json.example
+++ b/help.json.example
@@ -1,0 +1,16 @@
+{
+  "content": "",
+  "embed": {
+    "description":"",
+    "color":3447003,
+    "thumbnail": {
+      "url": ""
+    },
+    "fields": [
+      {
+        "name": "",
+        "value": ""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This bot was created for a Minecraft Discord server but the bot isn't specific to Minecraft. The only reference to MC exists in the help output.

This now instead uses whatever is defined in a file called `help.json`.