### PR TITLE
Remove with ID

### DIFF
--- a/cat_modules/parse_input.js
+++ b/cat_modules/parse_input.js
@@ -19,7 +19,7 @@ exports.run = (message, commands) => {
   const args = {};
   const actions = commands.map(c => c.name);
 
-  const re = `!cat (${actions.join('|')})\\s?(\\-(.*)\\s)?([^:]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
+  const re = `!cat (${actions.join('|')})\\s?(\\-(.\\w?)\\s)?([^:]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
   const matchedArgs = message.match(re);
   
   if (!matchedArgs) return args;

--- a/commands/purge.js
+++ b/commands/purge.js
@@ -4,18 +4,14 @@ module.exports = {
   usage: '!cat purge [username]',
   execute(message, args) {
     const logger = require('winston');
-    const catalogueSearch = require('../cat_modules/search_catalogue');
     const sqlite = require('../cat_modules/db');
-    const { admin_ids } = require('../config.json');
     const db = sqlite.load();
-    const user = message.author.username;
 
     db.run(`DELETE FROM listings
             WHERE seller = "${args.primary}"`, (err) => {
         if (err) logger.error(err);
-        message.channel.send(`Hi, ${user}! Any listings by that user have been removed.`);
-      });             
-
+        message.channel.send('Any listings by that user have been removed.');
+      });
   },
 
   valid(args) {

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -3,7 +3,6 @@ module.exports = {
   usage: '!cat remove [listing ID]',
   execute(message, args) {
     const logger = require('winston');
-    const catalogueSearch = require('../cat_modules/search_catalogue');
     const sqlite = require('../cat_modules/db');
     const { admin_ids } = require('../config.json');
     const db = sqlite.load();

--- a/commands/update.js
+++ b/commands/update.js
@@ -1,6 +1,6 @@
 module.exports = {
   name: 'update',
-  usage: '!cat update [option] [item]:[term]',
+  usage: '!cat update [option] [listing ID]:[updated value]',
   execute(message, args) {
     const logger = require('winston');
     const catalogueSearch = require('../cat_modules/search_catalogue');

--- a/commands/update.js
+++ b/commands/update.js
@@ -3,7 +3,6 @@ module.exports = {
   usage: '!cat update [option] [listing ID]:[updated value]',
   execute(message, args) {
     const logger = require('winston');
-    const catalogueSearch = require('../cat_modules/search_catalogue');
     const queryFromFlag = require('../cat_modules/query_from_flag');
     const sqlite = require('../cat_modules/db');
     const db = sqlite.load();

--- a/commands/update.js
+++ b/commands/update.js
@@ -9,26 +9,19 @@ module.exports = {
     const db = sqlite.load();
     const user = message.author.username;
 
-    let sql = `SELECT rowid, * FROM listings
-               WHERE item = "${args.primary}"
-               AND seller = "${user}"`
+    let sql = `UPDATE listings
+               SET ${queryFromFlag.run(args.flag)} = ?
+               WHERE rowid = "${args.primary}"
+               AND seller = "${user}"`;
 
-    const listingsSearch = catalogueSearch.run(sql);
-
-    listingsSearch.then((listing) => {
-      if (listing.length) {
-        let sql = `UPDATE listings
-                   SET ${queryFromFlag.run(args.flag)} = ?
-                   WHERE rowid = ${listing[0].rowid}`;
-
-        db.run(sql, args.secondary, (err) => {
-          if (err) logger.error(err);
-          message.channel.send(`Hi, ${user}! I've updated that listing for you.`);
-        });
+    db.run(sql, args.secondary, function(err) {
+      if (err) logger.error(err);
+      if (this.changes > 0) {
+        message.channel.send(`Hi, ${user}! I've updated that listing for you.`);
       } else {
-        message.channel.send(`Hi, ${user}! I couldn't find a listing for **${args.primary}** that belongs to you.`);
+        message.channel.send(`Sorry, ${user}. I couldn't find any listings that belonged to you with the ID given.`);
       }
-    }).catch((err) => logger.info(err));
+    });
   },
 
   valid(args) {


### PR DESCRIPTION
This changes updating and removing listings to use IDs instead of the wording of the listed item(s). This should make it easier to manage/understand. The downside to this, is that a user must know the ID in order to perform either of these actions, but the ID can be obtained via a detailed search.

One upside to this is bulk removal: `!cat remove 100, 101, 102`, for example would remove three listings with these IDs.

---

**Other changes**

* Fixed an issue where secondary values couldn't have spaces if a flag was present, so for example, updating a listings price with a multi-word value (e.g. "5 gold") would fail
* Tweaked bot response to unsuccessful commands
* Tidied up code slightly