### PR TITLE
Bulk update

### DIFF
--- a/commands/update.js
+++ b/commands/update.js
@@ -5,6 +5,8 @@ module.exports = {
     const fieldFromFlag = require('../cat_modules/field_from_flag');
     const db = require('../cat_modules/db').load();
 
+    const ids = args.primary.split(',')
+
     let sql = `UPDATE listings
                SET ${fieldFromFlag.run(args.flag)} = ?
                WHERE rowid = "${args.primary}"

--- a/commands/update.js
+++ b/commands/update.js
@@ -5,9 +5,10 @@ module.exports = {
     const fieldFromFlag = require('../cat_modules/field_from_flag');
     const db = require('../cat_modules/db').load();
 
+    const ids = args.primary.split(',').map(id => `"${id}"`);
     let sql = `UPDATE listings
                SET ${fieldFromFlag.run(args.flag)} = ?
-               WHERE rowid = "${args.primary}"
+               WHERE id in (${ids})
                AND userId = "${args.user.id}"`;
 
     return new Promise((resolve, reject) => {

--- a/commands/update.js
+++ b/commands/update.js
@@ -5,8 +5,6 @@ module.exports = {
     const fieldFromFlag = require('../cat_modules/field_from_flag');
     const db = require('../cat_modules/db').load();
 
-    const ids = args.primary.split(',')
-
     let sql = `UPDATE listings
                SET ${fieldFromFlag.run(args.flag)} = ?
                WHERE rowid = "${args.primary}"


### PR DESCRIPTION
#33 changed it so that removing or updating a listing uses an ID instead of the text of the listing. It also added bulk removal using a comma-separated list of IDs.

There's no reason that same technique can't be applied to updating as well. If you wanted to update the price of three listings, and the IDs of those listings were `10`, `20`, `30`, you could do:

`!cat update -p 10, 20, 30 : 5 gold`

This may also fix a silent error when attempting to rename a listing to the same name as one that already exists. 