### PR TITLE
Add users table

### DIFF
--- a/cat.js
+++ b/cat.js
@@ -1,6 +1,5 @@
 const { prefix, token } = require('./config.json');
 const inputParse = require('./cat_modules/parse_input');
-// const FindOrCreateUser = require('./cat_modules/user_create');
 const Discord = require('discord.js');
 const db = require('./cat_modules/db');
 const fs = require('fs');
@@ -57,42 +56,6 @@ client.on('message', message => {
       message.channel.send("Oops.. something went wrong. Please notify the author with how you did this.");
     }
   });
-
-  // ;
-  // const action = client.commands.get(args.action);
-  // let currentUser;
-
-  // user.find(message.author.id)//.then((u) => currentUser = u );
-
-  // // if (!action) {
-  // //   return promptHelp(message.channel, name);
-  // // }
-
-  // // if (action.adminLocked || action.write) {
-  // //   if (currentUser && currentUser.admin) {
-  // //     return promptHelp(message.channel, name);
-  // //   }
-  // // }
-
-  // if (!action.valid(args)) {
-  //   return replyTo(message.channel, name, {
-  //     success: false,
-  //     message: `Here's how you use that \`${action.usage}\`. See \`${prefix} help\` for more usage information.`
-  //   });
-  // }
-
-  // if (action.write && !currentUser) user.create(message.author.id, name);
-
-  // try {
-  //   action.execute(args).then((result) => {
-  //     replyTo(message.channel, name, result);
-  //   }).catch((err) => {
-  //     logger.info(err)
-  //   });
-  // } catch (error) {
-  //   logger.info(`${error}`);
-  //   message.channel.send("Oops.. something went wrong. Please notify the author with how you did this.");
-  // }
 });
 
 function promptHelp(channel, user) {

--- a/cat.js
+++ b/cat.js
@@ -1,6 +1,6 @@
 const { prefix, token } = require('./config.json');
-const userIsAdmin = require('./cat_modules/admin_check');
 const inputParse = require('./cat_modules/parse_input');
+// const FindOrCreateUser = require('./cat_modules/user_create');
 const Discord = require('discord.js');
 const db = require('./cat_modules/db');
 const fs = require('fs');
@@ -20,38 +20,79 @@ for (const file of commandFiles) {
 
 db.connect('./db/catalogue.db');
 
+const user = require('./cat_modules/user');
+
 client.on('message', message => {
   if (!message.content.startsWith(prefix) || message.author.bot) return;
+  const name = getRelativeName(message);
   const args = inputParse.run(message, client.commands);
-  const action = client.commands.get(args.action);
 
-  if (!action) {
-    return promptHelp(message.channel, args.user);
-  }
-
-  if (action.adminLocked) {
-    if (!userIsAdmin.run(args.userId)) {
-      return promptHelp(message.channel, args.user);
+  user.findOrCreate(message.author.id, name).then(user => {
+    args.user = user;
+  
+    const action = client.commands.get(args.action);
+    if (!action) {
+      return promptHelp(message.channel, name);
     }
-  }
 
-  if (!action.valid(args)) {
-    return replyTo(message.channel, args.user, {
-      success: false,
-      message: `Here's how you use that \`${ action.usage}\`. See \`${prefix} help\` for more usage information.`
-    });
-  }
+    if (action.adminLocked && !!!user.admin) {
+      return promptHelp(message.channel, name);
+    }
 
-  try {
-    action.execute(args).then((result) => {
-      replyTo(message.channel, args.user, result);
-    }).catch((err) => {
-      logger.info(err)
-    });
-  } catch (error) {
-    logger.info(`${error}`);
-    message.channel.send("Oops.. something went wrong. Please notify the author with how you did this.");
-  }
+    if (!action.valid(args)) {
+      return replyTo(message.channel, name, {
+        success: false,
+        message: `Here's how you use that \`${action.usage}\`. See \`${prefix} help\` for more usage information.`
+      });
+    }
+
+    try {
+      action.execute(args).then((result) => {
+        replyTo(message.channel, name, result);
+      }).catch((err) => {
+        logger.info(err)
+      });
+    } catch (error) {
+      logger.info(`${error}`);
+      message.channel.send("Oops.. something went wrong. Please notify the author with how you did this.");
+    }
+  });
+
+  // ;
+  // const action = client.commands.get(args.action);
+  // let currentUser;
+
+  // user.find(message.author.id)//.then((u) => currentUser = u );
+
+  // // if (!action) {
+  // //   return promptHelp(message.channel, name);
+  // // }
+
+  // // if (action.adminLocked || action.write) {
+  // //   if (currentUser && currentUser.admin) {
+  // //     return promptHelp(message.channel, name);
+  // //   }
+  // // }
+
+  // if (!action.valid(args)) {
+  //   return replyTo(message.channel, name, {
+  //     success: false,
+  //     message: `Here's how you use that \`${action.usage}\`. See \`${prefix} help\` for more usage information.`
+  //   });
+  // }
+
+  // if (action.write && !currentUser) user.create(message.author.id, name);
+
+  // try {
+  //   action.execute(args).then((result) => {
+  //     replyTo(message.channel, name, result);
+  //   }).catch((err) => {
+  //     logger.info(err)
+  //   });
+  // } catch (error) {
+  //   logger.info(`${error}`);
+  //   message.channel.send("Oops.. something went wrong. Please notify the author with how you did this.");
+  // }
 });
 
 function promptHelp(channel, user) {
@@ -82,6 +123,14 @@ function segmentedResponse(responseMessage) {
 
 function messageStart(actionSuccess, user) {
   return actionSuccess ? `Hi, ${user}! ` : `Sorry, ${user}. `
+}
+
+function getRelativeName(message) {
+  if (message.member) {
+    return message.member.nickname || message.author.username;
+  }
+
+  return message.author.username;
 }
 
 function replyTo(channel, user, result) {

--- a/cat_modules/admin_check.js
+++ b/cat_modules/admin_check.js
@@ -1,4 +1,0 @@
-exports.run = (userId) => {
-  const { admin_ids } = require('../config.json');
-  return admin_ids.includes(userId);
-}

--- a/cat_modules/db.js
+++ b/cat_modules/db.js
@@ -6,7 +6,7 @@ module.exports = {
     _db = new sqlite3.Database(file, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE, (err) => {
       _db.run(`CREATE TABLE IF NOT EXISTS users (
                id         INTEGER PRIMARY KEY,
-               discordId  TEXT,
+               discordId  TEXT UNIQUE,
                name       TEXT,
                admin      BOOLEAN)`);
 

--- a/cat_modules/db.js
+++ b/cat_modules/db.js
@@ -8,7 +8,7 @@ module.exports = {
                id         INTEGER PRIMARY KEY,
                discordId  TEXT UNIQUE,
                name       TEXT,
-               admin      BOOLEAN)`);
+               admin      BOOLEAN DEFAULT 0)`);
 
       _db.run(`CREATE TABLE IF NOT EXISTS listings (
                id       INTEGER PRIMARY KEY,
@@ -16,7 +16,9 @@ module.exports = {
                price    TEXT,
                userId   INTEGER,
                location TEXT,
-               FOREIGN KEY(userId) REFERENCES users(id))`);
+               FOREIGN KEY(userId)
+               REFERENCES users(id)
+               ON DELETE CASCADE)`);
     });
 
     return _db;

--- a/cat_modules/db.js
+++ b/cat_modules/db.js
@@ -2,23 +2,27 @@ const sqlite3 = require('sqlite3').verbose();
 let _db;
 
 module.exports = {
-  connect: function(file) {
+  connect(file) {
     _db = new sqlite3.Database(file, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE, (err) => {
-      if (err) {
-        console.error(err.message);
-      }
+      _db.run(`CREATE TABLE IF NOT EXISTS users (
+               id         INTEGER PRIMARY KEY,
+               discordId  TEXT,
+               name       TEXT,
+               admin      BOOLEAN)`);
+
       _db.run(`CREATE TABLE IF NOT EXISTS listings (
-               seller   TEXT,
+               id       INTEGER PRIMARY KEY,
                item     TEXT,
                price    TEXT,
+               userId   INTEGER,
                location TEXT,
-               CONSTRAINT unq UNIQUE (seller, item))`);
-      console.log('Catalogue loaded.');
-      return _db;
+               FOREIGN KEY(userId) REFERENCES users(id))`);
     });
+
+    return _db;
   },
 
-  load: function() {
+  load() {
     return _db;
   }
 }

--- a/cat_modules/field_from_flag.js
+++ b/cat_modules/field_from_flag.js
@@ -4,9 +4,9 @@ exports.run = (flag) => {
 
   switch(focusFlag) {
     case 's': // (s)eller
-      return 'seller';
+      return 'name';
     case 'u': // (u)ser (seller alt)
-      return 'seller';
+      return 'name';
     case 'i': // (i)tem
       return 'item';
     case 'b': // (b)lock (item alt)

--- a/cat_modules/parse_input.js
+++ b/cat_modules/parse_input.js
@@ -1,5 +1,9 @@
 exports.run = (message, commands) => {
   const logger = require('winston');
+  const actions = commands.map(c => c.name);
+  const args = {};
+  const re = `!cat (${actions.join('|')})\\s?(\\-(.\\w?)\\s)?([^:]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
+
   function toSafeString(str) {
     return str.replace(/[^ \w-@*()\[\]_#,\.'’]+/g, '').trim();
   }
@@ -16,11 +20,6 @@ exports.run = (message, commands) => {
     return args;
   }
 
-  const args = {};
-
-  const actions = commands.map(c => c.name);
-
-  const re = `!cat (${actions.join('|')})\\s?(\\-(.\\w?)\\s)?([^:]*)(?::([^:@]*\\b)(?:\\s@(.*))?)?`;
   const matchedArgs = message.content.match(re);
   
   if (!matchedArgs) return args;

--- a/cat_modules/parse_input.js
+++ b/cat_modules/parse_input.js
@@ -16,10 +16,7 @@ exports.run = (message, commands) => {
     return args;
   }
 
-  const args = {
-    user: message.author.username,
-    userId: message.author.id
-  };
+  const args = {};
 
   const actions = commands.map(c => c.name);
 

--- a/cat_modules/user.js
+++ b/cat_modules/user.js
@@ -2,10 +2,10 @@ const db = require('../cat_modules/db').load();
 
 module.exports = {
   findOrCreate(discordId, name) {
-    const sql = `INSERT OR IGNORE INTO users (discordId, name, admin)
-                 VALUES (?, ?, ?)`;
+    const sql = `INSERT OR IGNORE INTO users (discordId, name)
+                 VALUES (?, ?)`;
 
-    db.run(sql, [discordId, name, 0]);
+    db.run(sql, [discordId, name]);
 
     return new Promise((resolve, reject) => {
       db.get(`SELECT * FROM users WHERE discordId = ?`, [discordId], (err, row) => {

--- a/cat_modules/user.js
+++ b/cat_modules/user.js
@@ -1,0 +1,17 @@
+const db = require('../cat_modules/db').load();
+
+module.exports = {
+  findOrCreate(discordId, name) {
+    const sql = `INSERT OR IGNORE INTO users (discordId, name, admin)
+                 VALUES (?, ?, ?)`;
+
+    db.run(sql, [discordId, name, 0]);
+
+    return new Promise((resolve, reject) => {
+      db.get(`SELECT * FROM users WHERE discordId = ?`, [discordId], (err, row) => {
+        if (err) reject(err);
+        resolve(row);
+      });
+    });
+  }
+}

--- a/cat_modules/user_create.js
+++ b/cat_modules/user_create.js
@@ -1,7 +1,0 @@
-exports.run = async (discordId, name) => {
-  const db = require('./db').load();
-  const sql = `INSERT OR IGNORE INTO users (discordId, name)
-               VALUES (?, ?)`;
-
-  await db.run(sql, [discordId, name]);
-};

--- a/cat_modules/user_create.js
+++ b/cat_modules/user_create.js
@@ -1,0 +1,7 @@
+exports.run = async (discordId, name) => {
+  const db = require('./db').load();
+  const sql = `INSERT OR IGNORE INTO users (discordId, name)
+               VALUES (?, ?)`;
+
+  await db.run(sql, [discordId, name]);
+};

--- a/commands/add.js
+++ b/commands/add.js
@@ -11,7 +11,7 @@ module.exports = {
         if (err) reject(err);
         resolve({ 
           success: true,
-          message: `I've added **${args.primary}** to the catalogue for you with an listing ID of **${this.lastID}**. You'll need this ID to remove or update this listing later.`
+          message: `I've added **${args.primary}** to the catalogue for you with an listing ID of **${this.lastID}**.`
         });
       });
     });

--- a/commands/add.js
+++ b/commands/add.js
@@ -2,28 +2,19 @@ module.exports = {
   name: 'add',
   usage: '!cat add [item]:[price]',
   execute(args) {
-    const sqlite = require('../cat_modules/db');
-    const db = sqlite.load();
-    const sql = `INSERT INTO listings (seller, item, price, location)
+    const db = require('../cat_modules/db').load();
+    const sql = `INSERT INTO listings (item, price, userId, location)
                  VALUES (?, ?, ?, ?)`;
 
-    const actionResult = new Promise((resolve, reject) => {
-      db.run(sql, [args.user, args.primary, args.secondary, args.optional], function(err) {
-        if (err && err.code === 'SQLITE_CONSTRAINT') {
-          resolve({ 
-            success: false,
-            message: `You already have a **${args.primary}** listing.`
-          });
-        } else {
-          resolve({ 
-            success: true,
-            message: `I've added **${args.primary}** to the catalogue for you with an listing ID of **${this.lastID}**. You'll need this ID to remove or update this listing later.`
-          });
-        }
+    return new Promise((resolve, reject) => {
+      db.run(sql, [args.primary, args.secondary, args.user.id, args.optional], function(err) {
+        if (err) reject(err);
+        resolve({ 
+          success: true,
+          message: `I've added **${args.primary}** to the catalogue for you with an listing ID of **${this.lastID}**. You'll need this ID to remove or update this listing later.`
+        });
       });
     });
-
-    return actionResult;
   },
 
   valid(args) {

--- a/commands/admin.js
+++ b/commands/admin.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: 'admin',
+  adminLocked: true,
+  usage: '!cat admin [option] [Discord ID]',
+  execute(args) {
+  },
+
+  valid(args) {
+    return !!args.flag && !!args.primary
+  }
+}

--- a/commands/admin.js
+++ b/commands/admin.js
@@ -1,11 +1,34 @@
 module.exports = {
   name: 'admin',
   adminLocked: true,
-  usage: '!cat admin [option] [Discord ID]',
+  usage: '!cat admin [add|remove]:[Discord ID]',
   execute(args) {
+    const db = require('../cat_modules/db').load();
+    let sql = `UPDATE users
+               SET admin = ?
+               WHERE discordId = "${args.secondary}"`;
+
+    const val = args.primary === 'add' ? '1' : '0'
+
+    return new Promise((resolve, reject) => {
+      db.run(sql, val, function(err) {
+        if (err) reject(err);
+        if (this.changes > 0) {
+          resolve({
+            success: true,
+            message: "That's all done for you."
+          });
+        } else {
+          resolve({
+            success: false,
+            message: 'No user was found with that Discord ID.'
+          });
+        }
+      })
+    })
   },
 
   valid(args) {
-    return !!args.flag && !!args.primary
+    return ['add', 'remove'].includes(args.primary) && !!args.secondary
   }
 }

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -1,16 +1,15 @@
 module.exports = {
-  name: 'remove',
-  usage: '!cat remove [listing ID]',
+  name: 'delete',
+  adminLocked: true,
+  usage: '!cat delete [listing ID]',
   execute(args) {
     const db = require('../cat_modules/db').load();
 
     const ids = args.primary.split(', ').map(id => `"${id}"`);
-    const sql = `DELETE FROM listings
-                 WHERE id in (${ids})
-                 AND userId = "${args.user.id}"`;
 
     return new Promise((resolve, reject) => {
-      db.run(sql, function(err) {
+      db.run(`DELETE FROM listings
+              WHERE rowid in (${ids})`, function(err) {
         if (err) reject(err);
         if (this.changes > 0) {
           resolve({
@@ -20,7 +19,7 @@ module.exports = {
         } else {
           resolve({
             success: false,
-            message: "I couldn't find any listings that belonged to you with the IDs given."
+            message: 'No listings were removed. If this was unexpected then double check the IDs given.'
           });
         }
       });

--- a/commands/help.js
+++ b/commands/help.js
@@ -3,14 +3,10 @@ module.exports = {
   execute() {
     const description = require('../help.json');
 
-    const actionResult = new Promise((resolve, reject) => {
-      resolve({
-        success: true,
-        message: description
-      });
+    return Promise.resolve({
+      success: true,
+      message: description
     });
-
-    return actionResult;
   },
 
   valid(args) {

--- a/commands/purge.js
+++ b/commands/purge.js
@@ -1,23 +1,23 @@
 module.exports = {
   name: 'purge',
   adminLocked: true,
-  usage: '!cat purge [username]',
+  usage: '!cat purge [Discord ID]',
   execute(args) {
     const db = require('../cat_modules/db').load();
 
     return new Promise((resolve, reject) => {
-      db.run(`DELETE FROM listings
-              WHERE seller = "${args.primary}"`, function(err) {
+      db.run(`DELETE FROM users
+              WHERE discordId = "${args.primary}"`, function(err) {
         if (err) reject(err);
         if (this.changes > 0) {
           resolve({
             success: true,
-            message: 'Any listings by that user have been removed.'
+            message: 'That user, and any listings belonging to that user, have been removed from the catalogue.'
           });
         } else {
           resolve({
             success: false,
-            message: 'No listings were removed. If this was unexpected then double check the username given is exact.'
+            message: "I couldn't find a user in the catalogue with that ID, are you sure it's correct?"
           });
         }
       });

--- a/commands/purge.js
+++ b/commands/purge.js
@@ -3,10 +3,9 @@ module.exports = {
   adminLocked: true,
   usage: '!cat purge [username]',
   execute(args) {
-    const sqlite = require('../cat_modules/db');
-    const db = sqlite.load();
+    const db = require('../cat_modules/db').load();
 
-    const actionResult = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       db.run(`DELETE FROM listings
               WHERE seller = "${args.primary}"`, function(err) {
         if (err) reject(err);
@@ -23,8 +22,6 @@ module.exports = {
         }
       });
     });
-
-    return actionResult;
   },
 
   valid(args) {

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -4,7 +4,7 @@ module.exports = {
   execute(args) {
     const db = require('../cat_modules/db').load();
 
-    const ids = args.primary.split(', ').map(id => `"${id}"`);
+    const ids = args.primary.split(',').map(id => `"${id}"`);
     const sql = `DELETE FROM listings
                  WHERE id in (${ids})
                  AND userId = "${args.user.id}"`;

--- a/commands/search.js
+++ b/commands/search.js
@@ -1,22 +1,21 @@
 module.exports = {
   name: 'search',
-  usage: '!cat search [option] [item]',
+  usage: '!cat search [option] [search term]',
   execute(args) {
     const fieldFromFlag = require('../cat_modules/field_from_flag');
     const db = require('../cat_modules/db').load();
 
     const field = fieldFromFlag.run(args.flag);
-
-    const sql = `SELECT rowid, * FROM listings
-                 WHERE LOWER(${field})
-                 LIKE LOWER("%${args.primary.replace('*', '')}%")`
-
-
-    // Need some fancy joins here to maintain the level of search that is currently possible. Hm..        
-
+    
+    let sql = `SELECT listings.*, users.name 
+               FROM listings
+               INNER JOIN users on users.id = listings.userId
+               WHERE LOWER(${field})
+               LIKE LOWER("%${args.primary.replace('*', '')}%")` 
+ 
     function resultMessage(result) {
-      const details = `[**id:** ${result.rowid}, **owner:** ${result.seller}] `;
-      let response = `**${result.location || result.seller}** is selling **${result.item}** for **${result.price}**`;
+      const details = `[**id:** ${result.id}, **owner:** ${result.name}] `;
+      let response = `**${result.location || result.name}** is selling **${result.item}** for **${result.price}**`;
 
       if (verbose()) {
         response = details + response;

--- a/commands/search.js
+++ b/commands/search.js
@@ -4,8 +4,7 @@ module.exports = {
   execute(args) {
     const fieldFromFlag = require('../cat_modules/field_from_flag');
     const pluralize = require('pluralize');
-    const sqlite = require('../cat_modules/db');
-    const db = sqlite.load();
+    const db = require('../cat_modules/db').load();
 
     const field = fieldFromFlag.run(args.flag);
 
@@ -33,7 +32,7 @@ module.exports = {
       return (args.flag && args.flag.includes('v'));
     }
 
-    const actionResult = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       db.all(sql, (err, listings) => {
         if (err) reject(err);
 
@@ -47,8 +46,6 @@ module.exports = {
         });
       });
     });
-
-    return actionResult;
   },
 
   valid(args) {

--- a/commands/seller.js
+++ b/commands/seller.js
@@ -1,15 +1,14 @@
 module.exports = {
-  name: 'delete',
-  adminLocked: true,
-  usage: '!cat delete [listing ID]',
+  name: 'seller',
+  usage: '!cat seller name : [seller name]',
   execute(args) {
     const db = require('../cat_modules/db').load();
-
-    const ids = args.primary.split(',').map(id => `"${id}"`);
+    let sql = `UPDATE users
+               SET name = "${args.secondary}"
+               WHERE discordId = "${args.user.discordId}"`;
 
     return new Promise((resolve, reject) => {
-      db.run(`DELETE FROM listings
-              WHERE rowid in (${ids})`, function(err) {
+      db.run(sql, function(err) {
         if (err) reject(err);
         if (this.changes > 0) {
           resolve({
@@ -19,14 +18,14 @@ module.exports = {
         } else {
           resolve({
             success: false,
-            message: 'No listings were removed. If this was unexpected then double check the IDs given.'
+            message: 'Something went wrong.. please try again, or notify the author if this keeps happening.'
           });
         }
-      });
-    });
+      })
+    })
   },
 
   valid(args) {
-    return !!args.primary;
+    return ['name'].includes(args.primary) && !!args.secondary
   }
 }

--- a/commands/update.js
+++ b/commands/update.js
@@ -8,7 +8,7 @@ module.exports = {
     let sql = `UPDATE listings
                SET ${fieldFromFlag.run(args.flag)} = ?
                WHERE rowid = "${args.primary}"
-               AND seller = "${args.user}"`;
+               AND userId = "${args.user.id}"`;
 
     return new Promise((resolve, reject) => {
       db.run(sql, args.secondary, function(err) {

--- a/commands/update.js
+++ b/commands/update.js
@@ -3,15 +3,14 @@ module.exports = {
   usage: '!cat update [option] [listing ID]:[updated value]',
   execute(args) {
     const fieldFromFlag = require('../cat_modules/field_from_flag');
-    const sqlite = require('../cat_modules/db');
-    const db = sqlite.load();
+    const db = require('../cat_modules/db').load();
 
     let sql = `UPDATE listings
                SET ${fieldFromFlag.run(args.flag)} = ?
                WHERE rowid = "${args.primary}"
                AND seller = "${args.user}"`;
 
-    const actionResult = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       db.run(sql, args.secondary, function(err) {
         if (err) reject(err);
         if (this.changes > 0) {
@@ -27,8 +26,6 @@ module.exports = {
         }
       });
     });
-
-    return actionResult;
   },
 
   valid(args) {

--- a/commands/users.js
+++ b/commands/users.js
@@ -1,0 +1,31 @@
+module.exports = {
+  name: 'users',
+  adminLocked: true,
+  usage: '!cat users',
+  execute(args) {
+    const db = require('../cat_modules/db').load();
+
+    function formatUser(user) {
+      return `• **id:** ${user.id}, **DiscordID:** ${user.discordId}, **name:** ${user.name}, **admin:** ${user.admin}`;
+    }
+
+    return new Promise((resolve, reject) => {
+      db.all('SELECT * FROM users', (err, users) => {
+        if (err) reject(err);
+
+        users = users.map(user => {
+          return formatUser(user);
+        })
+
+        resolve({
+          success: true,
+          message: `Here you go: \n\n${users.join("\n")}`
+        });
+      })
+    });
+  },
+
+  valid(args) {
+    return true;
+  }
+}

--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,4 @@
 {
 	"prefix": "",
-	"token": "",
-	"admin ids": [
-		
-	]
+	"token": ""
 }


### PR DESCRIPTION
Quite a few problems exist around users:

1. A username (seller) owns a listing
2. Usernames are used instead of nicknames in responses
3. Username is duplicated across however many listings they own
4. An admin is defined in a config file making adding/removing difficult

The solutions to these is to break out the user from listings into its own table. This new table would have fields such as: `discordId`, `name`, and `admin`. A user in this table would have many listings by association.

The Discord ID would own the listing, freeing up the `name` to be whatever the owner wants it to be. The name is purely for the listings, so it could be the Discord username, Discord server nickname, or in-game username, shop name, etc.

---

Other things will be included as part of this users table:

**Admin command**

An admin locked command to add or remove other admins.

Usage: `!cat admin [add|remove] : [Discord ID]`

**Users command**

An admin locked command to return users details. Returns Discord ID, names, and admin status.

Usage: `!cat users`

**Delete command**

The admin locked variant of `!cat remove`. It seemed cleaner to keep these two separate rather than making an admin check whenever a listing is removed.

Usage: `!cat delete [comma separated listing IDs]`

**Seller command**

Now that username doesn't own a listing we can modify it freely. Seller is what or who is selling the item, this could be the Discord username, Discord server nickname, in-game name, etc.

Usage: `!cat seller name : Bob`

**Relative names in bot response**

Bot will address the user by the correct name in responses. If the user has a server nickname, it'll use that, otherwise it'll continue to use the username.