### PR TITLE
The first admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Something to note:
 
 ## Admin
 
-A catalogue admin can modify or remove the sellers and listings of other users. They can also remove a user from the catalogue entirely. Most admin commands around users require the user's Discord ID. This can be obtained by: `!cat user list`.
+**Note:** Adding the first admin is slightly different from adding subsequent admins. This can be done by adding your Discord ID to the config and running: `!cat user makemeadmin`. This technique may change in the future.
+
+A catalogue admin can modify or remove the sellers and listings of other users. Most admin commands around users require the user's Discord ID. This can be obtained by: `!cat user list`.
 
 ### Adding or Removing admins
 

--- a/cat_modules/responder.js
+++ b/cat_modules/responder.js
@@ -36,7 +36,8 @@ module.exports = {
   },
 
   respondWithHelp(channel, subCommands) {
-    const formattedsubCommands = module.exports.formatSubCommandHelp(subCommands);
+    const filteredSubCommands = module.exports.filterSubCommands(subCommands)
+    const formattedsubCommands = module.exports.formatSubCommandHelp(filteredSubCommands);
     channel.send(`\`\`\`${formattedsubCommands}\`\`\``);
   },
 
@@ -54,5 +55,10 @@ module.exports = {
     });
   
     return helpEntries.join("\n");
+  },
+
+  filterSubCommands(subCommands) {
+    Object.keys(subCommands).map(sc => { if (subCommands[sc].excludeFromHelp) delete subCommands[sc] });
+    return subCommands;
   }
 }

--- a/commands/user.js
+++ b/commands/user.js
@@ -11,6 +11,20 @@ module.exports = {
       }
     },
 
+    makemeadmin: {
+      usage: 'admin self',
+      description: 'Make yourself an admin',
+      excludeFromHelp: true,
+      execute() {
+        const { adminDiscordId } = require('../config.json');
+        return db.run(
+          `UPDATE users
+           SET admin = 1
+           WHERE discordId = "${adminDiscordId}"`
+        );
+      }
+    },
+
     help: {
       usage: 'user help',
       description: 'Shows this',

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,7 @@
 {
 	"prefix": "!cat",
-	"token": ""
+	"token": "",
+	"status": "!cat help",
+	"statusType": "PLAYING",
+	"adminDiscordId": ""
 }


### PR DESCRIPTION
Currently, only admins can add other admins which raises the obvious question - if there are no admins, how can one be made? This aims to solve that. The solution ins't ideal but it'll work for now given this isn't something that'll likely happen often.

The solution belongs in the config file - `adminDiscordId`. If this is defined, then running `!cat user makemeadmin` will take the Discord ID and make the user an admin.

This also adds `excludeFromHelp` to the sub-commands. If this is set to `true` in any sub-command then it will not appear in the command help.

This also updates the config example to include `status` and `statusType` which can be used to set the status of the bot. This was added in a previous commit but I forgot to update the example.