### PR TITLE
Enable PRAGMA FK, remove trigger

### DIFF
--- a/cat_modules/db.js
+++ b/cat_modules/db.js
@@ -10,7 +10,7 @@ module.exports = {
          discordId      TEXT UNIQUE,
          name           TEXT,
          admin          BOOLEAN DEFAULT 0,
-         defaultSeller  INTEGER)`
+         defaultSeller  INTEGER REFERENCES sellers(id) ON DELETE SET NULL)`
       );
 
       _db.run(
@@ -26,23 +26,16 @@ module.exports = {
       );
 
       _db.run(
-        `CREATE TRIGGER IF NOT EXISTS nullifyDefaultSeller AFTER DELETE ON sellers
-         BEGIN
-          UPDATE users SET defaultSeller = NULL
-            WHERE defaultSeller = OLD.id;
-         END;`
-      );
-
-      _db.run(
         `CREATE TABLE IF NOT EXISTS listings (
          id       INTEGER PRIMARY KEY,
          item     TEXT,
          price    TEXT,
-         userId   INTEGER,
-         sellerId INTEGER,
-         FOREIGN KEY(sellerId) REFERENCES sellers(id) ON DELETE CASCADE)`
+         userId   INTEGER REFERENCES users(id) ON DELETE CASCADE,
+         sellerId INTEGER REFERENCES sellers(id))`
       );
     });
+
+    _db.get("PRAGMA foreign_keys = ON")
 
     return _db;
   },

--- a/commands/listing.js
+++ b/commands/listing.js
@@ -2,7 +2,7 @@ const db = require('../cat_modules/db_query');
 
 module.exports = {
   name: 'listing',
-  description: "A listing is an item or service for a price. They must belong to a seller",
+  description: "A listing is an item or service for a price. Listings belong to sellers",
   subCommands: {
     add: {
       usage: 'listing add [item]:[price] @[seller name]',


### PR DESCRIPTION
Two problems:

1. When creating a DB for the first time it will error when creating the trigger because the table it is for doesn't "exist" at the time of creating it
2. `ON DELETE CASCADE` was not working. Purge depends on this, so purge does not work as expected

I've addressed the first by removing the trigger in favour of setting up `ON DELETE SET NULL`. This should do exactly what the trigger was created to do.

I've addressed the second by enabling PRAGMA FK which for some reason is turned off by default. This was never found in testing as I use a GUI to test DB stuff which has this PRAGMA enabled by default.