### PR TITLE
Search only listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,15 @@ Some things to note:
 
 ### Searching listings
 
-A user can search for listings by the name of the item or service, or the seller:
+A user can search for listings by name:
 
 **Usage:** `!cat listing search [:term]`\
-**Example 1:** `!cat listing search 5 books`\
-**Example 2:** `!cat listing search My Shop`
+**Example 1:** `!cat listing search books`\
 
 Some things to note:
 
 * Search is partial; "book" would return any listings with book in the listing or seller name
-* Search is capped at 10 results
+* Search is capped at 10 by default but can be changed in the config
 
 ### Modfying a listing
 

--- a/commands/listing.js
+++ b/commands/listing.js
@@ -1,4 +1,5 @@
 const db = require('../cat_modules/db_query');
+const { searchCap } = require('../config.json');
 
 module.exports = {
   name: 'listing',
@@ -59,14 +60,7 @@ module.exports = {
                      FROM listings
                      INNER JOIN sellers on sellers.id = listings.sellerId
                      WHERE LOWER("item") LIKE LOWER("${term}")
-                       OR LOWER("name") LIKE LOWER("${term}")
-                     LIMIT 10;
-                     ORDER BY
-                     CASE
-                       WHEN LOWER("item") LIKE '${term}' THEN 1
-                       WHEN LOWER("name") LIKE '${term}' THEN 2
-                       ELSE 3
-                     END`
+                     LIMIT ${searchCap}`
 
         return db.all(sql, 'listings');
       }

--- a/config.json.example
+++ b/config.json.example
@@ -3,5 +3,6 @@
 	"token": "",
 	"status": "!cat help",
 	"statusType": "PLAYING",
-	"adminDiscordId": ""
+	"adminDiscordId": "",
+	"searchCap": "10"
 }


### PR DESCRIPTION
I've seen some confusion around listing searches. The current logic looks through listing names then through seller names and returns results in that order, but this in combination with the search cap meant that some stuff was getting buried without making search terms more specific to try and narrow it down further.

This updates search to only look through listings, and makes the search cap configurable.