### PR TITLE
Toggle seller visibility

### DIFF
--- a/cat_modules/db.js
+++ b/cat_modules/db.js
@@ -21,6 +21,7 @@ module.exports = {
          icon        TEXT,
          colour      STRING,
          description TEXT,
+         active      BOOLEAN DEFAULT 1,
          userId      INTEGER,
          FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE)`
       );

--- a/commands/listing.js
+++ b/commands/listing.js
@@ -56,10 +56,11 @@ module.exports = {
       argsPattern: /(?<term>.+)/,
       execute(args) {
         const term = `%${args.term.replace('*', '')}%`;
-        const sql = `SELECT listings.id, listings.item, listings.price, sellers.name
+        const sql = `SELECT listings.id, listings.item, listings.price, sellers.name, sellers.active
                      FROM listings
                      INNER JOIN sellers on sellers.id = listings.sellerId
-                     WHERE LOWER("item") LIKE LOWER("${term}")
+                     WHERE sellers.active = 1
+                     AND LOWER("item") LIKE LOWER("${term}")
                      LIMIT ${searchCap}`
 
         return db.all(sql, 'listings');

--- a/commands/seller.js
+++ b/commands/seller.js
@@ -109,7 +109,11 @@ module.exports = {
                   {
                     "name": "Name",
                     "value": `${result.name}`,
-                    'inline': true,
+                    'inline': true
+                  },
+                  {
+                    "name": "Active",
+                    "value": `${result.active ? 'Yes' : 'No'}`
                   },
                   {
                     "name": "Location",
@@ -145,6 +149,21 @@ module.exports = {
              WHERE id = "${user.id}"`, errOnFail
           );
         });
+      }
+    },
+
+    toggle: {
+      usage: 'seller toggle [seller ID]',
+      description: 'Toggle seller visibility',
+      argsPattern: /(?<sellerId>[0-9]+)/,
+      execute(args, user) {
+        const errOnFail = `I couldn't find a seller with that ID that belongs to you.`
+        let sql = `UPDATE sellers
+                   SET active = NOT active
+                   WHERE id = "${args.sellerId}"`
+
+        if (!user.admin) sql = sql + ` AND userId = "${user.id}"`;
+        return db.run(sql, errOnFail);
       }
     },
 


### PR DESCRIPTION
Request to enable "suspending" a seller for a period of inactivity. It was agreed that the best approach would to be able to toggle it.

A seller can be made active/inactive with: `!cat seller toggle [:id]`

Listings of an inactive seller will not appear in search results but the seller can still be queried directly; this is open to change.